### PR TITLE
Fix hash function to agree with raftis server

### DIFF
--- a/src/main/java/com/volkangurel/raftis/RaftisClientImpl.java
+++ b/src/main/java/com/volkangurel/raftis/RaftisClientImpl.java
@@ -99,9 +99,7 @@ public final class RaftisClientImpl extends RaftisClient {
     @Override
     protected RaftisReplicaSet getReplicaSet(String key) {
         int slot = slotForKey(key);
-        System.out.println("Got slot " + slot + " for key " + key);
         RaftisReplicaSet ret = slotReplicaSets.get(slot);
-        System.out.println("Replicas for slot: " + ret);
         return ret;
 
     }

--- a/src/main/java/com/volkangurel/raftis/RaftisClientImpl.java
+++ b/src/main/java/com/volkangurel/raftis/RaftisClientImpl.java
@@ -108,12 +108,11 @@ public final class RaftisClientImpl extends RaftisClient {
 
     private int slotForKey(String key) {
         if (key == null) { return 0; }
-        ByteBuffer bytes = StandardCharsets.UTF_8.encode(key);
+        byte[] b = key.getBytes();
         int sum = 0;
-        for (int i : bytes.array()) {
-            sum = (sum * 17) + i;
+        for (byte i : b) {
+            sum = (sum * 17) + (byte)i;
         }
-        System.out.println("Got hash " + Math.abs(sum) + " for key " + key);
         return Math.abs(sum) % config.getNumSlots();
     }
 }

--- a/src/main/java/com/volkangurel/raftis/RaftisClientImpl.java
+++ b/src/main/java/com/volkangurel/raftis/RaftisClientImpl.java
@@ -27,6 +27,7 @@ public final class RaftisClientImpl extends RaftisClient {
         for (RaftisShardConfig shardConfig : config.getShards()) {
             RaftisReplicaSetImpl replicaSet = new RaftisReplicaSetImpl(shardConfig, config, poolConfig);
             for (Integer slot : shardConfig.getSlots()) {
+                System.err.println("Storing set " + replicaSet + " for slot " + slot);
                 slotReplicaSets.put(slot, replicaSet);
             }
         }
@@ -63,7 +64,9 @@ public final class RaftisClientImpl extends RaftisClient {
                 try {
                     jedis = pool.getResource();
                     String json = jedis.configGet("cluster").get(1);
+                    System.err.println("Got cluster json " + json + " from seed " + seed.getHost() + ":" + seed.getPort());
                     RaftisConfig config = RaftisConfig.parseJSON(json);
+                    System.err.println("Parsed config " + config.toString());
                     config.setLocalGroup(localGroup);
                     pool.returnResource(jedis);
                     pool.destroy();
@@ -96,15 +99,21 @@ public final class RaftisClientImpl extends RaftisClient {
     @Override
     protected RaftisReplicaSet getReplicaSet(String key) {
         int slot = slotForKey(key);
-        return slotReplicaSets.get(slot);
+        System.out.println("Got slot " + slot + " for key " + key);
+        RaftisReplicaSet ret = slotReplicaSets.get(slot);
+        System.out.println("Replicas for slot: " + ret);
+        return ret;
+
     }
 
     private int slotForKey(String key) {
+        if (key == null) { return 0; }
         ByteBuffer bytes = StandardCharsets.UTF_8.encode(key);
         int sum = 0;
         for (int i : bytes.array()) {
             sum = (sum * 17) + i;
         }
+        System.out.println("Got hash " + Math.abs(sum) + " for key " + key);
         return Math.abs(sum) % config.getNumSlots();
     }
 }

--- a/src/main/java/com/volkangurel/raftis/RaftisReplicaSetImpl.java
+++ b/src/main/java/com/volkangurel/raftis/RaftisReplicaSetImpl.java
@@ -16,6 +16,7 @@ public class RaftisReplicaSetImpl extends RaftisReplicaSet {
     private final RaftisConfig raftisConfig;
     private final RaftisPoolConfig poolConfig;
     private final Map<String, RaftisPool> pools = new HashMap<String, RaftisPool>();
+    private final String myName;
 
     public RaftisReplicaSetImpl(RaftisShardConfig config, RaftisConfig raftisConfig,
                                 RaftisPoolConfig poolConfig) {
@@ -25,14 +26,16 @@ public class RaftisReplicaSetImpl extends RaftisReplicaSet {
 
         JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();
         jedisPoolConfig.setMaxIdle(poolConfig.getMaxIdle());
-
+        StringBuffer name = new StringBuffer();
         for (RaftisShardHostConfig host : config.getHosts()) {
             if (pools.containsKey(host.getGroup())) {
                 throw new RuntimeException("Duplicate group in replica set: " + host.getGroup() + " config: " + config.toString());
             }
+            name.append("|" + host.getHost() +":"+ host.getPort() + ":" + host.getGroup() + "|");
             pools.put(host.getGroup(),
                     new RaftisPool(jedisPoolConfig, host.getHost(), host.getPort(), poolConfig.getTimeout()));
         }
+        myName = name.toString();
     }
 
     @Override
@@ -51,5 +54,10 @@ public class RaftisReplicaSetImpl extends RaftisReplicaSet {
             throw new RuntimeException("pool not found for local group " + raftisConfig.getLocalGroup());
         }
         return pool;
+    }
+
+    @Override
+    public String toString() {
+        return myName;
     }
 }

--- a/src/main/java/com/volkangurel/raftis/config/RaftisPoolConfig.java
+++ b/src/main/java/com/volkangurel/raftis/config/RaftisPoolConfig.java
@@ -2,7 +2,7 @@ package com.volkangurel.raftis.config;
 
 
 public class RaftisPoolConfig {
-    private volatile int timeout = 1000;
+    private volatile int timeout = 5000;
     private volatile int maxIdle = 10;
 
     public RaftisPoolConfig setTimeout(int timeout) {

--- a/src/main/java/com/volkangurel/raftis/pool/RaftisPoolFactory.java
+++ b/src/main/java/com/volkangurel/raftis/pool/RaftisPoolFactory.java
@@ -32,6 +32,7 @@ public class RaftisPoolFactory implements PooledObjectFactory<Jedis> {
     @Override
     public PooledObject<Jedis> makeObject() throws Exception {
         final Jedis jedis = new Jedis(this.host, this.port, this.timeout);
+        System.out.println("Instantiating new jedis connection to " + this.host + ":" + this.port);
         jedis.connect();
         connectionsCreated.incrementAndGet();
         return new DefaultPooledObject<Jedis>(jedis);

--- a/src/main/java/com/volkangurel/raftis/pool/RaftisPoolFactory.java
+++ b/src/main/java/com/volkangurel/raftis/pool/RaftisPoolFactory.java
@@ -32,7 +32,6 @@ public class RaftisPoolFactory implements PooledObjectFactory<Jedis> {
     @Override
     public PooledObject<Jedis> makeObject() throws Exception {
         final Jedis jedis = new Jedis(this.host, this.port, this.timeout);
-        System.out.println("Instantiating new jedis connection to " + this.host + ":" + this.port);
         jedis.connect();
         connectionsCreated.incrementAndGet();
         return new DefaultPooledObject<Jedis>(jedis);


### PR DESCRIPTION
Hey, so my performance problems were because something is weird with the ByteBuffer translation you did using UTF-8 -- it yields different results than calling String.getBytes(), and they disagree with the server.  Mystifying that UTF-8 would translate differnetly for a string of all hex, where each UTF-8 encoding is guaranteed to be 1 byte per char...  but whatever.

This caused performance problems because when you call a host that doesn't have that key, it issues a PING request followed by the GET request, to ensure consistency -- this was causing my read benchmark to execute 3 writes (1 for each replica) per read, hence crappy results.

Will keep you posted on benchmarks once I get some better ones.
